### PR TITLE
add http setting for a MCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,69 @@ The following is the **recommended default configuration** for this server withi
 - Refer to the "Environment Variables" table below for a detailed description of each variable and its default.
 - The server's behavior is primarily controlled by these environment variables. While an `ods_config.json` file can also influence settings (see Configuration Management), environment variables passed by the MCP client take precedence.
 
+## HTTP Server Mode (FastMCP)
+
+In addition to the default stdio transport, the server can expose an MCP endpoint over HTTP using [FastMCP](https://github.com/jlowin/fastmcp). This is useful for clients that connect via HTTP rather than spawning a subprocess.
+
+### Starting the HTTP Server
+
+```bash
+python mcp_server.py --http
+```
+
+The server will start on `0.0.0.0:8000` by default and accept MCP requests at:
+
+```
+http://<host>:<port>/mcp
+```
+
+All origins are allowed (CORS is fully open), so the endpoint is accessible from any client or browser-based tool.
+
+### HTTP Server Environment Variables
+
+| Variable         | Description                        | Default     |
+|------------------|------------------------------------|-------------|
+| `MCP_HTTP_HOST`  | Host address to bind to            | `0.0.0.0`   |
+| `MCP_HTTP_PORT`  | Port to listen on                  | `8000`      |
+
+**Example — custom host and port:**
+
+```bash
+MCP_HTTP_HOST=127.0.0.1 MCP_HTTP_PORT=9000 python mcp_server.py --http
+```
+
+**Windows (Command Prompt):**
+```cmd
+set MCP_HTTP_HOST=127.0.0.1
+set MCP_HTTP_PORT=9000
+python mcp_server.py --http
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:MCP_HTTP_HOST="127.0.0.1"
+$env:MCP_HTTP_PORT="9000"
+python mcp_server.py --http
+```
+
+### Connecting an MCP Client via HTTP
+
+Point your MCP client at the `/mcp` endpoint:
+
+```json
+{
+  "mcpServers": {
+    "mcp-searxng-enhanced-http": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+> **Note:** All server configuration variables (`SEARXNG_ENGINE_API_BASE_URL`, `DESIRED_TIMEZONE`, etc.) apply in HTTP mode exactly as they do in stdio mode. The `ods_config.json` file is written at startup before the server begins accepting connections.
+
+---
+
 ## Running Natively (Without Docker)
 
 If you prefer to run the server directly using Python without Docker, follow these steps:
@@ -123,7 +186,7 @@ If you prefer to run the server directly using Python without Docker, follow the
      ```bash
      pip install -r requirements.txt
      ```
-     Key dependencies include `httpx`, `BeautifulSoup4`, `pydantic`, `trafilatura`, `python-dateutil`, `cachetools`, `zoneinfo`, `filetype`, `pymupdf` and `pymupdf4llm`.
+     Key dependencies include `httpx`, `BeautifulSoup4`, `pydantic`, `trafilatura`, `python-dateutil`, `cachetools`, `zoneinfo`, `filetype`, `pymupdf`, `pymupdf4llm`, and `fastmcp`.
 
 **5. Ensure SearXNG is Accessible:**
    - You still need a running SearXNG instance. Make sure you have its API base URL (e.g., `http://127.0.0.1:8080/search`).
@@ -148,11 +211,17 @@ If you prefer to run the server directly using Python without Docker, follow the
    - Refer to the "Environment Variables" table below for all available options. If not set, defaults from the script or an `ods_config.json` file (if present in the root directory or at `ODS_CONFIG_PATH`) will be used.
 
 **7. Run the Server:**
-   - Execute the Python script:
+   - **stdio mode** (default — for MCP clients that spawn a subprocess):
      ```bash
      python mcp_server.py
      ```
-   - The server will start and listen for MCP client connections via stdin/stdout.
+     The server listens for MCP client connections via stdin/stdout.
+
+   - **HTTP mode** (for MCP clients that connect via HTTP):
+     ```bash
+     python mcp_server.py --http
+     ```
+     The server starts a FastMCP HTTP endpoint at `http://0.0.0.0:8000/mcp`. See [HTTP Server Mode](#http-server-mode-fastmcp) for configuration options.
 
 **8. Configuration File (`ods_config.json`):**
    - Alternatively, or in combination with environment variables, you can create an `ods_config.json` file in the project's root directory (or the path specified by the `ODS_CONFIG_PATH` environment variable). Environment variables will always take precedence over values in this file. Example:
@@ -170,6 +239,8 @@ The following environment variables control the server's behavior. You can set t
 | Variable                        | Description                                | Default (from Dockerfile)         | Notes                                                                                                |
 |---------------------------------|--------------------------------------------|-----------------------------------|------------------------------------------------------------------------------------------------------|
 | `SEARXNG_ENGINE_API_BASE_URL`   | SearXNG search endpoint                    | `http://host.docker.internal:8080/search` | **Crucial for server operation**                                                                     |
+| `MCP_HTTP_HOST`                 | Bind address for HTTP server mode          | `0.0.0.0`                         | Only used when starting with `--http`                                                               |
+| `MCP_HTTP_PORT`                 | Port for HTTP server mode                  | `8000`                            | Only used when starting with `--http`                                                               |
 | `DESIRED_TIMEZONE`              | Timezone for date/time tool                | `America/New_York`                | E.g., `America/Los_Angeles`. List of tz database time zones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
 | `ODS_CONFIG_PATH`               | Path to persistent configuration file      | `/config/ods_config.json`         | Typically left as default within the container.     |
 | `RETURNED_SCRAPPED_PAGES_NO`    | Max pages to return per search             | `3`                               |                                                       |
@@ -293,6 +364,8 @@ Errors are properly propagated to the client with informative messages.
 - **Rate limit errors**: Adjust `RATE_LIMIT_REQUESTS_PER_MINUTE` if you're experiencing too many rate limit errors.
 - **Slow content extraction**: Increase `TRAFILATURA_TIMEOUT` to allow more time for content processing on complex pages.
 - **Docker networking issues**: If using Docker Desktop on Windows/Mac, `host.docker.internal` should resolve to the host machine. On Linux, you may need to use the host's IP address instead.
+- **HTTP mode not reachable**: Ensure no firewall is blocking `MCP_HTTP_PORT` (default `8000`). Set `MCP_HTTP_HOST=0.0.0.0` to bind on all interfaces, or `127.0.0.1` to restrict to localhost only.
+- **HTTP mode session ID error**: The server runs in stateless HTTP mode — each POST to `/mcp` is self-contained. If your client requires session-based transport, switch to stdio mode instead.
 
 ## Acknowledgements
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -26,6 +26,9 @@ from zoneinfo import ZoneInfo
 import filetype
 import pymupdf
 import pymupdf4llm
+from fastmcp import FastMCP
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
 
 # --- Custom Exceptions ---
 class MCPServerError(Exception):
@@ -432,7 +435,7 @@ class Tools:
         except Exception as e:
             logger.error(f"Failed to save config: {e}")
 
-    def __init__(self, send_notification_func: Callable[[str, Any], Awaitable[None]]):
+    def __init__(self, send_notification_func: Optional[Callable[[str, Any], Awaitable[None]]] = None):
         """
         Initialize the Tools class with configuration from script defaults, config file, and environment variables.
         Configuration is loaded in the following priority order:
@@ -444,6 +447,11 @@ class Tools:
         - It doesn't exist yet (first-time initialization)
         - Environment variables are explicitly provided for this run
         """
+        if send_notification_func is None:
+            async def _noop(method: str, params: Any) -> None:
+                pass
+            send_notification_func = _noop
+
         # 1. Load defaults from script
         script_defaults = self.Valves().dict()
         
@@ -868,6 +876,40 @@ class Tools:
         formatted_datetime = now_desired.strftime("%A, %B %d, %Y at %I:%M %p (%Z)")
         return f"The current date and time is {formatted_datetime}"
 
+# --- FastMCP HTTP Server ---
+_fastmcp = FastMCP("mcp-searxng-enhanced", version="1.1.0")
+_http_tools: Optional[Tools] = None
+
+def _get_http_tools() -> Tools:
+    global _http_tools
+    if _http_tools is None:
+        _http_tools = Tools()
+    return _http_tools
+
+@_fastmcp.tool(
+    description="Search the web for various categories (general, images, videos, files, map, social media, news, it, science). Scrapes text for web categories, returns specific data for others. Provides citations. Allows optional filtering. Is able to read PDF files and convert to Markdown."
+)
+async def search_web(
+    query: str,
+    engines: Optional[str] = None,
+    category: str = "general",
+    safesearch: Optional[str] = None,
+    time_range: Optional[str] = None,
+) -> str:
+    return await _get_http_tools().search_web(query, engines, category, safesearch, time_range)
+
+@_fastmcp.tool(
+    description="Scrape content from web pages (using Trafilatura, converting Reddit to old.reddit). Caches results and provides citations. Is able to read PDF files and convert these to Markdown."
+)
+async def get_website(url: str) -> str:
+    return await _get_http_tools().get_website(url)
+
+@_fastmcp.tool(
+    description="Get the current date and time in the configured timezone."
+)
+def get_current_datetime() -> str:
+    return _get_http_tools().get_current_datetime()
+
 # --- JSON-RPC Communication ---
 async def send_json_rpc(data: Dict[str, Any]):
     message_str = json.dumps(data)
@@ -1049,11 +1091,32 @@ async def main():
     logger.info("MCP Server exiting.")
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        logger.info("KeyboardInterrupt received, exiting.")
-        sys.exit(0)
-    except Exception as e:
-        logging.critical(f"Fatal error starting server: {e}", exc_info=True)
-        sys.exit(1)
+    if "--http" in sys.argv:
+        http_host = os.getenv("MCP_HTTP_HOST", "0.0.0.0")
+        http_port = int(os.getenv("MCP_HTTP_PORT", "8000"))
+        _get_http_tools()  # eagerly init so config file is written on start
+        logger.info(f"Starting FastMCP HTTP server on {http_host}:{http_port}/mcp")
+        _fastmcp.run(
+            transport="http",
+            host=http_host,
+            port=http_port,
+            path="/mcp",
+            stateless_http=True,
+            middleware=[
+                Middleware(
+                    CORSMiddleware,
+                    allow_origins=["*"],
+                    allow_methods=["*"],
+                    allow_headers=["*"],
+                )
+            ],
+        )
+    else:
+        try:
+            asyncio.run(main())
+        except KeyboardInterrupt:
+            logger.info("KeyboardInterrupt received, exiting.")
+            sys.exit(0)
+        except Exception as e:
+            logging.critical(f"Fatal error starting server: {e}", exc_info=True)
+            sys.exit(1)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -394,6 +394,8 @@ class Tools:
         RATE_LIMIT_REQUESTS_PER_MINUTE: int = Field(default=10, ge=1, le=60)
         RATE_LIMIT_TIMEOUT_SECONDS: int = Field(default=60, ge=10, le=3600)
         CACHE_MAX_AGE_MINUTES: int = Field(default=30, ge=1, le=1440)
+        MCP_HTTP_HOST = str = Field(default="0.0.0.0")
+        MCP_HTTP_PORT = str = Field(default="8080")
         
         @validator('SEARXNG_ENGINE_API_BASE_URL')
         def validate_searxng_url(cls, v):

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -394,8 +394,8 @@ class Tools:
         RATE_LIMIT_REQUESTS_PER_MINUTE: int = Field(default=10, ge=1, le=60)
         RATE_LIMIT_TIMEOUT_SECONDS: int = Field(default=60, ge=10, le=3600)
         CACHE_MAX_AGE_MINUTES: int = Field(default=30, ge=1, le=1440)
-        MCP_HTTP_HOST = str = Field(default="0.0.0.0")
-        MCP_HTTP_PORT = str = Field(default="8080")
+        MCP_HTTP_HOST: str = Field(default="0.0.0.0")
+        MCP_HTTP_PORT: str = Field(default="8080")
         
         @validator('SEARXNG_ENGINE_API_BASE_URL')
         def validate_searxng_url(cls, v):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+fastmcp>=3.0.0,<4.0.0
 httpx>=0.20.0,<1.0.0
 beautifulsoup4>=4.9.0,<5.0.0
 pydantic>=1.8.0,<3.0.0
@@ -8,3 +9,4 @@ cachetools>=5.0.0,<6.0.0 # For caching get_website results
 filetype>=1.1.0,<2.0.0 # For detecting file types when processing get_website results
 pymupdf>=1.20.0,<2.0.0 # For converting PDFs to plaintext
 pymupdf4llm>=0.0.20,<0.1 # For MD formatting of converted PDFs
+lxml_html_clean 


### PR DESCRIPTION
Adds a new HTTP Server Mode so can be added to llama.cpp, claude cli, or opencode via an mcp server.

Written with claude ai , so understand if you do not merge. Tested in llama.cpp and works great!